### PR TITLE
Add a plugin.zsh file so this can be autocloned by zsh frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,26 @@ A) "What if ping was different on every build of linux. Shit gets old."
 
 Q) I'm not sure. The `dscacheutil -flushcache` command he lists for Snow Leopard still works for me (OS X Yosemite here).
 A) The command didn't fail, but it didn't clear the cache either: (HT masklinn https://news.ycombinator.com/item?id=11902754)
+
+# Installing
+
+### Bash / not using any frameworks
+
+If you're using bash, or aren't using a framework, just clone this repository and add it to your `$PATH`.
+
+### [Antigen](https://github.com/zsh-users/antigen)
+
+Add `antigen bundle eventi/noreallyjustfuckingstopalready` to your `.zshrc` with your other bundle commands.
+
+Antigen will handle cloning the plugin for you automatically the next time you start zsh. You can also add the plugin to a running zsh with `antigen bundle eventi/noreallyjustfuckingstopalready` for testing before adding it to your `.zshrc`.
+
+### [Oh-My-Zsh](http://ohmyz.sh/)
+
+1. `cd ~/.oh-my-zsh/custom/plugins`
+2. `git clone git@github.com:eventi/noreallyjustfuckingstopalready.git`
+3. Add the repo to your plugin list
+
+### [Zgen](https://github.com/tarjoilija/zgen)
+
+Add `zgen load eventi/noreallyjustfuckingstopalready` to your .zshrc file in the same function you're doing your other `zgen load` calls in.
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # noreallyjustfuckingstopalready
+
 Please OS X (or whatever your name is) just fucking reset your DNS cache please
 
 F.A.Q
@@ -30,5 +31,4 @@ Antigen will handle cloning the plugin for you automatically the next time you s
 
 ### [Zgen](https://github.com/tarjoilija/zgen)
 
-Add `zgen load eventi/noreallyjustfuckingstopalready` to your .zshrc file in the same function you're doing your other `zgen load` calls in.
-
+Add `zgen load eventi/noreallyjustfuckingstopalready` to your .zshrc file in the same function you're doing your other `zgen load` calls in. zgen will take care of cloning the repository and adding it to your `$PATH`.

--- a/noreallyjustfuckingstopalready.plugin.zsh
+++ b/noreallyjustfuckingstopalready.plugin.zsh
@@ -1,0 +1,9 @@
+# Do plugin setup to make this easily loadable by oh-my-zsh, zgen and other
+# oh-my-zsh-compatible frameworks
+
+if [[ "$(uname -s)" = "Darwin" ]]; then
+  # Add the plugin's diretory to user's path
+  PLUGIN_HOME="$(dirname $0)"
+  export PATH=${PATH}:${PLUGIN_HOME}
+  alias flush-osx-cache=flush.sh
+fi


### PR DESCRIPTION
Rather than having to keep checking back to see if there are updates, make the repo loadable by antigen/oh-my-zsh/zgen. Antigen and Zgen are both smart enough so that you can have them automatically check for updates periodically so you get the updated version when Apple
inevitably breaks things in a future OS release.
