### PR TITLE
make bpkg friendly

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,17 @@
 Please OS X (or whatever your name is) just fucking reset your DNS cache please
 
+Installation:
+
+With https://github.com/bpkg/bpkg do:
+
+  $ bpkg install -g eventi/noreallyjustfuckingstopalready
+
+From source:
+
+  $ git clone https://github.com/eventi/noreallyjustfuckingstopalready.git
+  $ cd noreallyjustfuckingstopalready
+  $ install -b flu.sh ${PREFIX:-/usr/local}/bin/flu.sh
+
 F.A.Q
 
 Q) What? Why?

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "noreallyjustfuckingstopalready",
+  "repo": "eventi/noreallyjustfuckingstopalready",
+  "version": "0.0.1",
+  "description": "Please OS X just fucking reset your DNS cache please",
+  "global": "1",
+  "install": "install -b flu.sh ${PREFIX:-/usr/local}/bin/flu.sh",
+  "scripts": ["flu.sh"]
+}


### PR DESCRIPTION
This commit adds [bpkg](https://github.com/bpkg/bpkg) and source installation instructions to the `README`.
It also creates a `package.json` file to make installation with `bpkg` simple.
