### PR TITLE
Add zsh plugin file

### DIFF
--- a/README
+++ b/README
@@ -12,6 +12,22 @@ From source:
   $ cd noreallyjustfuckingstopalready
   $ install -b flu.sh ${PREFIX:-/usr/local}/bin/flu.sh
 
+Antigen
+
+Add `antigen bundle eventi/noreallyjustfuckingstopalready` to your `.zshrc` with your other bundle commands.
+
+Antigen will handle cloning the plugin for you automatically the next time you start zsh. You can also add the plugin to a running zsh with `antigen bundle eventi/noreallyjustfuckingstopalready` for testing before adding it to your `.zshrc`.
+
+Oh-My-Zsh
+
+1. `cd ~/.oh-my-zsh/custom/plugins`
+2. `git clone git@github.com:eventi/noreallyjustfuckingstopalready.git`
+3. Add the repo to your plugin list
+
+Zgen
+
+Add `zgen load eventi/noreallyjustfuckingstopalready` to your .zshrc file in the same function you're doing your other `zgen load` calls in. zgen will take care of cloning the repository and adding it to your `$PATH`.
+
 F.A.Q
 
 Q) What? Why?

--- a/noreallyjustfuckingstopalready.plugin.zsh
+++ b/noreallyjustfuckingstopalready.plugin.zsh
@@ -1,0 +1,9 @@
+# Do plugin setup to make this easily loadable by oh-my-zsh, zgen and other
+# oh-my-zsh-compatible frameworks
+
+if [[ "$(uname -s)" = "Darwin" ]]; then
+  # Add the plugin's diretory to user's path
+  PLUGIN_HOME="$(dirname $0)"
+  export PATH=${PATH}:${PLUGIN_HOME}
+  alias flush-osx-cache=flu.sh
+fi


### PR DESCRIPTION
Rather than having to keep checking back to see if there are updates, make the repo loadable by antigen/oh-my-zsh/zgen. Antigen and Zgen are both smart enough so that you can have them automatically check for updates periodically so you get the updated version when Apple inevitably breaks things in a future OS release.

Out of curiosity, why did you change from markdown format for the README?
